### PR TITLE
added empty_with validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ The field under validation must contain only alphabetic characters and spaces.
 
 The given field must be a well formed domainname.
 
+### empty_with:foo,bar,...
+
+Either the field under validation must be empty, or all of the other specified fields.
+
 ## Changing the error messages:
 
 Add the corresponding key to `/resources/lang/<language>/validation.php` like this:

--- a/src/Intervention/Validation/Validator.php
+++ b/src/Intervention/Validation/Validator.php
@@ -387,4 +387,17 @@ class Validator
 
         return (boolean) preg_match($pattern, $value);
     }
+
+    public static function isEmptyWith($value, $values)
+    {
+        if (strlen($value) === 0) {
+            return true;
+        }
+
+        $values = array_filter($values, function ($item) {
+            return strlen($item) > 0;
+        });
+
+        return empty($values);
+    }
 }

--- a/src/Intervention/Validation/ValidatorExtension.php
+++ b/src/Intervention/Validation/ValidatorExtension.php
@@ -127,4 +127,20 @@ class ValidatorExtension extends \Illuminate\Validation\Validator
     {
         return Validator::isDomainname($value);
     }
+
+    /**
+     * Provides 'empty_with' validation rule for Laravel
+     *
+     * @return bool
+     */
+    public function validateEmptyWith($attribute, $value, $parameters)
+    {
+        $values = [];
+
+        foreach ($parameters as $parameter) {
+            $values[] = $this->getValue($parameter);
+        }
+
+        return Validator::isEmptyWith($value, $values);
+    }
 }

--- a/src/lang/en/validation.php
+++ b/src/lang/en/validation.php
@@ -14,5 +14,6 @@ return array(
     'password' => ':attribute must contain 6 to 64 characters including at least one digit, one upper case letter, one lower case letter and one special symbol.',
     'alpha_space' => ':attribute must contain only alphabetic characters and spaces.',
     'domainname' => ':attribute must be a well formed domainname.',
+    'empty_with' => 'Either :attribute or the other fields must be filled, not all fields.',
 
 );

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -28,7 +28,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase
         $no_iban = 'GR82 WEST 1234 5698 7654 32';
         $this->assertTrue(Validator::isIban($iban));
         $this->assertFalse(Validator::isIban($no_iban));
-        
+
         $no_iban = '5070081';
         $this->assertFalse(Validator::isIban($no_iban));
     }
@@ -165,8 +165,8 @@ class ValidationTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Validator::isHtmlclean('<0>'));
         $this->assertFalse(Validator::isHtmlclean('<>'));
         $this->assertFalse(Validator::isHtmlclean('><'));
-        
-        
+
+
     }
 
     public function testValidatePassword()
@@ -257,5 +257,13 @@ class ValidationTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Validator::isDomainname('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.bar'));
         $this->assertFalse(Validator::isDomainname('bar.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'));
         $this->assertFalse(Validator::isDomainname('xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx'));
+    }
+
+    public function testValidateEmptyWith()
+    {
+        $this->assertTrue(Validator::isEmptyWith('foo', []));
+        $this->assertTrue(Validator::isEmptyWith('', ['foo']));
+
+        $this->assertFalse(Validator::isEmptyWith('foo', ['bar']));
     }
 }


### PR DESCRIPTION
I've added an empty_with validator that checks if either the field under validation is empty or all of the other specified fields. With this validator you can make an `either [this field] or [that field]` validation.