### PR TITLE
Improve the testings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: php
+
+dist: 'precise'
+
+php:
+  - '5.3'
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+
+cache:
+  directories:
+    - ./vendor
+
+install:
+  - composer install
+
+script:
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+after_success:
+  - travis_retry vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "illuminate/validation": "~4|~5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.8",
+        "php-coveralls/php-coveralls": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,10 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/Intervention/Validation/Validator.php</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Intervention/Validation/Validator.php
+++ b/src/Intervention/Validation/Validator.php
@@ -13,7 +13,7 @@ class Validator
      */
     public static function isIsin($value)
     {
-        $chars = [
+        $chars = array(
              10 => 'A',
              11 => 'B',
              12 => 'C',
@@ -40,15 +40,15 @@ class Validator
              33 => 'X',
              34 => 'Y',
              35 => 'Z',
-        ];
+        );
 
         $checkdigit = substr($value, -1);
 
         $value = substr($value, 0, -1);
         $value = str_replace($chars, array_keys($chars), $value);
 
-        $g1 = [];
-        $g2 = [];
+        $g1 = array();
+        $g2 = array();
 
         foreach (str_split($value) as $key => $num) {
             if ($key % 2 == 0) {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -280,9 +280,9 @@ class ValidationTest extends PHPUnit_Framework_TestCase
 
     public function testValidateEmptyWith()
     {
-        $this->assertTrue(Validator::isEmptyWith('foo', []));
-        $this->assertTrue(Validator::isEmptyWith('', ['foo']));
+        $this->assertTrue(Validator::isEmptyWith('foo', array()));
+        $this->assertTrue(Validator::isEmptyWith('', array('foo')));
 
-        $this->assertFalse(Validator::isEmptyWith('foo', ['bar']));
+        $this->assertFalse(Validator::isEmptyWith('foo', array('bar')));
     }
 }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -49,6 +49,12 @@ class ValidationTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Validator::isCreditcard($no_cc));
     }
 
+    public function testValidateCreditcardWithValueLenthIsInvalid()
+    {
+        $invalid = '123';
+        $this->assertFalse(Validator::isCreditcard($invalid));
+    }
+
     public function testValidateHexcolor()
     {
         // hex
@@ -76,6 +82,12 @@ class ValidationTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(Validator::isIsbn($isbn2));
         $this->assertTrue(Validator::isIsbn($isbn3));
         $this->assertFalse(Validator::isIsbn($no_isbn));
+    }
+
+    public function testValidateIsbnWithValueIsNotNumeric()
+    {
+        $invalid = 'invalidxxx';
+        $this->assertFalse(Validator::isIsbn($invalid));
     }
 
     public function testValidateIsodate()


### PR DESCRIPTION
# Changed log
- improve the testings.
- set the correct settings in ```phpunit.xml```.
- hook the [Travis-CI](https://travis-ci.org/peter279k/validation) and [coveralls](https://coveralls.io/github/peter279k/validation) service. They're the CI and code coverage service.
- Because of setting the required PHP version is 5.3+ in ```composer.json```, I test all of the PHP 5.3+ in ```.travis.yml```.
- Accoring to this [issue](https://github.com/travis-ci/travis-ci/issues/7693), I set the dist is precise for completing the PHP 5.3 testing.

IMHO, the ```return false;``` in ```Validator.php``` should be changed into ```InValidArgumentException``` because the value passed by the methods is invalid.
What do you think?

Thanks.