### PR TITLE
Accepts underscore as special symbol in password validation rule

### DIFF
--- a/src/Intervention/Validation/Validator.php
+++ b/src/Intervention/Validation/Validator.php
@@ -353,7 +353,7 @@ class Validator
      */
     public static function isPassword($value)
     {
-        $pattern = "/^((?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\W]).{6,64})$/";
+        $pattern = "/^((?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\W_]).{6,64})$/";
         return (boolean) preg_match($pattern, $value);
     }
 

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -210,7 +210,8 @@ class ValidationTest extends TestCase
             'y0mAma!',
             '2&c5DSo',
             'PW3n_9B,{)Jj[\'Z}oe[[n.W',
-            '<Br0wn>'
+            '<Br0wn>',
+            'Pass_w0rd'
         );
 
         $bad = array(


### PR DESCRIPTION
Underscore is not recognized as special symbol in password validation rule.
It's because the PCRE \W token matches anything except letters, digits or underscore (for some reasons).