### PR TITLE
Add Finnish translations to error messages

### DIFF
--- a/src/lang/fi/validation.php
+++ b/src/lang/fi/validation.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'isin' => ':attribute tulee olla kelvollinen International Securities Identification Number (ISIN).',
+    'iban' => ':attribute tulee olla kelvollinen International Bank Account Number (IBAN).',
+    'bic' => ':attribute tulee olla kelvollinen Business Identifier Code (BIC).',
+    'hexcolor' => ':attribute tulee olla kelvollinen heksadesimaali värikoodi.',
+    'creditcard' => ':attribute tulee olla kelvollinen luottokortin numero.',
+    'isbn' => ':attribute tulee olla kelvollinen International Standard Book Number (ISBN).',
+    'username' => ':attribute tulee olla kelvollinen käyttäjänimi.',
+    'htmlclean' => ':attribute sisältää kiellettyä HTML-koodia.',
+    'domainname' => ':attribute tulee olla kelvollinen verkkoalueen nimi.',
+    'jwt' => ':attribute ei vastaa JSON Web Token muotoa',
+    'imei' => ':attribute tulee olla kelvollinen Mobile Equipment Identity (IMEI).',
+    'macaddress' => ':attribute tulee olla kelvollinen MAC-osoite.',
+    'slug' => ':attribute tulee olla kelvollinen polkutunnus',
+    'semver' => ':attribute tulee olla kelvollinen semanttisen versionumeroinnin versionumero.',
+    'luhn' => ':attribute tarkistussummaa ei voida vahvistaa Luhnin algoritmilla.',
+    'base64' => ':attribute tulee olla kelvollinen base64-muotoinen arvo.',
+    'issn' => ':attribute tulee olla kelvollinen International Standard Serial Number (ISSN).',
+    'lowercase' => ':attribute voi sisältää vain pieniä kirjaimia.',
+    'uppercase' => ':attribute voi sisältää vain isoja kirjaimia.',
+    'titlecase' => ':attribute kaikkien sanojen tulee alkaa isolla alkukirjaimella.',
+    'kebabcase' => ':attribute tulee olla käytetty kebab case kirjoitusasua.',
+    'snakecase' => ':attribute tulee olla käytetty snake case kirjoitusasua.',
+    'camelcase' => ':attribute tulee olla käytetty camel case kirjoitusasua.',
+];


### PR DESCRIPTION
Add Finnish translations to validation error messages.

Use localization specific terms where possible.

For example "slug" translates to "polkutunnus" as it used in Finnish WordPress localization