### PR TITLE
Added the test value as test message so it is returned when a test fails

### DIFF
--- a/tests/Rules/AbstractRuleTestCase.php
+++ b/tests/Rules/AbstractRuleTestCase.php
@@ -53,7 +53,7 @@ abstract class AbstractRuleTestCase extends TestCase
     public function testValid()
     {
         foreach ($this->valid as $value) {
-            $this->assertTrue((new $this->classname($value))->isValid(), $value);
+            $this->assertTrue((new $this->classname($value))->isValid(), (string) $value);
         }
     }
 
@@ -61,7 +61,7 @@ abstract class AbstractRuleTestCase extends TestCase
     {
 
         foreach ($this->invalid as $value) {
-            $this->assertFalse((new $this->classname($value))->isValid(), $value);
+            $this->assertFalse((new $this->classname($value))->isValid(), (string) $value);
         }
     }
 }

--- a/tests/Rules/AbstractRuleTestCase.php
+++ b/tests/Rules/AbstractRuleTestCase.php
@@ -53,7 +53,7 @@ abstract class AbstractRuleTestCase extends TestCase
     public function testValid()
     {
         foreach ($this->valid as $value) {
-            $this->assertTrue((new $this->classname($value))->isValid());
+            $this->assertTrue((new $this->classname($value))->isValid(), $value);
         }
     }
 
@@ -61,7 +61,7 @@ abstract class AbstractRuleTestCase extends TestCase
     {
 
         foreach ($this->invalid as $value) {
-            $this->assertFalse((new $this->classname($value))->isValid());
+            $this->assertFalse((new $this->classname($value))->isValid(), $value);
         }
     }
 }


### PR DESCRIPTION
I have added a message to the test cases in the rule tester so that when a test fails, it also outputs which value(s) failed the test.
(non strings are cast to strings so no errors will occur if the value to test is not a string)