### PR TITLE
Added Morocco 'MA' IBAN length

### DIFF
--- a/src/Rules/Iban.php
+++ b/src/Rules/Iban.php
@@ -52,6 +52,7 @@ class Iban extends AbstractStringRule
         'LI' => 21,
         'LT' => 20,
         'LU' => 20,
+        'MA' => 28,
         'MK' => 19,
         'MT' => 31,
         'MR' => 27,


### PR DESCRIPTION
Hi there,

Thanks for this package, really helpful! Morocco was missing in the IBAN number rule so I quickly added it.

Have a great day!