### PR TITLE
load rule class name with digits

### DIFF
--- a/src/Laravel/ValidationExtension.php
+++ b/src/Laravel/ValidationExtension.php
@@ -50,7 +50,7 @@ class ValidationExtension extends IlluminateValidator
      */
     private function getRuleClassnameByMethodName($name): string
     {
-        preg_match("/^validate((?P<rule>[a-zA-Z]+))$/", $name, $matches);
+        preg_match("/^validate((?P<rule>[a-zA-Z0-9]+))$/", $name, $matches);
 
         return 'Intervention\\Validation\\Rules\\' . data_get($matches, 'rule');
     }


### PR DESCRIPTION
Fixed bug related to loading a rule class name with digits