### PR TITLE
chore: support for Laravel 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.3|^7.4|^8.0",
-        "illuminate/validation": "~7|~8"
+        "illuminate/validation": "~7|~8|~9"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Adds support for Laravel v9. All units tests are running succesfully on this version.