### PR TITLE
Fixed issue when checksum remainder is 0

### DIFF
--- a/src/Rules/Ean.php
+++ b/src/Rules/Ean.php
@@ -39,7 +39,7 @@ class Ean extends AbstractRule implements Rule
      */
     public function passes($attribute, $value)
     {
-        return $this->hasAllowedLength($value) && $this->checksumMatches($value);
+        return is_numeric($value) && $this->hasAllowedLength($value) && $this->checksumMatches($value);
     }
 
     /**
@@ -83,10 +83,17 @@ class Ean extends AbstractRule implements Rule
     {
         $checksum = 0;
         $chars = array_reverse(str_split(substr($value, 0, -1), 1));
+
         foreach ($chars as $key => $char) {
             $checksum += ($key % 2 === 1) ? intval($char) * 1 : intval($char) * 3;
         }
 
-        return 10 - $checksum % 10;
+        $remainder = $checksum % 10;
+
+        if ($remainder === 0) {
+            return 0;
+        }
+
+        return 10 - $remainder;
     }
 }

--- a/src/Rules/Gtin.php
+++ b/src/Rules/Gtin.php
@@ -28,7 +28,7 @@ class Gtin extends Ean implements Rule
     public function passes($attribute, $value)
     {
         // GTIN-14 or GTIN-12 must be 14 or 12 chars including indicator digit and must have matching checksum
-        $valid = $this->hasAllowedLength($value) && $this->hasValidIndicatorDigit($value) && $this->gtinChecksumMatches($value);
+        $valid = is_numeric($value) && $this->hasAllowedLength($value) && $this->hasValidIndicatorDigit($value) && $this->gtinChecksumMatches($value);
 
         // GTIN-13, GTIN-8 is the same as EAN-13 and EAN-8
         return parent::passes($attribute, $value) || ($valid);
@@ -53,7 +53,6 @@ class Gtin extends Ean implements Rule
     protected function gtinChecksumMatches($value): bool
     {
         $data = substr($value, 1); // strip indicator digit
-
         return parent::getModuloChecksum($data) === parent::getValueChecksum($data);
     }
 }

--- a/tests/Rules/EanTest.php
+++ b/tests/Rules/EanTest.php
@@ -49,6 +49,7 @@ class EanTest extends TestCase
     public function dataProvider()
     {
         return [
+            [true, '9789510475270'],
             [true, '4012345678901'],
             [true, '0712345678911'],
             [true, '5901234123457'],
@@ -56,7 +57,6 @@ class EanTest extends TestCase
             [true, '96385074'],
             [true, '65833254'],
             [false, 'foo'],
-            [false, '0000000000000'],
             [false, '0000000000001'],
             [false, 'FFFFFFFFFFFFF'],
             [false, 'FFFFFFFFFFFF0'],
@@ -74,6 +74,7 @@ class EanTest extends TestCase
     public function dataProviderEan13()
     {
         return [
+            [true, '9789510475270'],
             [true, '4012345678901'],
             [true, '0712345678911'],
             [true, '5901234123457'],

--- a/tests/Rules/GtinTest.php
+++ b/tests/Rules/GtinTest.php
@@ -73,6 +73,7 @@ class GtinTest extends TestCase
     public function dataProvider()
     {
         return [
+            [true, '9789510475270'],
             [true, '4012345678901'],
             [true, '0712345678911'],
             [true, '5901234123457'],
@@ -84,7 +85,6 @@ class GtinTest extends TestCase
             [true, '012345000041'],
             [true, '012345000058'],
             [false, 'foo'],
-            [false, '0000000000000'],
             [false, '0000000000001'],
             [false, 'FFFFFFFFFFFFF'],
             [false, 'FFFFFFFFFFFF0'],
@@ -112,7 +112,6 @@ class GtinTest extends TestCase
             [false, '012345000041'],
             [false, '012345000058'],
             [false, 'foo'],
-            [false, '0000000000000'],
             [false, '0000000000001'],
             [false, 'FFFFFFFFFFFFF'],
             [false, 'FFFFFFFFFFFF0'],
@@ -140,7 +139,6 @@ class GtinTest extends TestCase
             [true, '012345000041'],
             [true, '012345000058'],
             [false, 'foo'],
-            [false, '0000000000000'],
             [false, '0000000000001'],
             [false, 'FFFFFFFFFFFFF'],
             [false, 'FFFFFFFFFFFF0'],
@@ -157,6 +155,7 @@ class GtinTest extends TestCase
     public function dataProviderGtin13()
     {
         return [
+            [true, '9789510475270'],
             [true, '4012345678901'],
             [true, '0712345678911'],
             [true, '5901234123457'],
@@ -168,7 +167,6 @@ class GtinTest extends TestCase
             [false, '012345000041'],
             [false, '012345000058'],
             [false, 'foo'],
-            [false, '0000000000000'],
             [false, '0000000000001'],
             [false, 'FFFFFFFFFFFFF'],
             [false, 'FFFFFFFFFFFF0'],
@@ -196,7 +194,6 @@ class GtinTest extends TestCase
             [false, '012345000041'],
             [false, '012345000058'],
             [false, 'foo'],
-            [false, '0000000000000'],
             [false, '0000000000001'],
             [false, 'FFFFFFFFFFFFF'],
             [false, 'FFFFFFFFFFFF0'],


### PR DESCRIPTION
There was in issue with GTIN and EAN when the module remainder was zero. See [Wikipedia ](https://en.wikipedia.org/wiki/ISBN#ISBN-13_check_digit_calculation)for this special rule.

"Subtracted from 10, that leaves a result from 1 to 10. A zero replaces a ten, so, in all cases, a single check digit results."

Had to remove 0000000000000 === false from the tests, since technically it is now a valid GTIN/EAN. I also added a check that the value has to be numeric.