### PR TITLE
Added GS1 prefix check for ISBN's

### DIFF
--- a/src/Rules/Isbn.php
+++ b/src/Rules/Isbn.php
@@ -37,7 +37,7 @@ class Isbn extends Ean implements Rule
                 return $this->shortChecksumMatches($value);
 
             case 13:
-                return parent::checksumMatches($value); // isbn-13 is a subset of ean-13
+                return preg_match("/^(978|979)/", $value) && parent::checksumMatches($value); // isbn-13 is a subset of ean-13
         }
 
         return false;

--- a/tests/Rules/IsbnTest.php
+++ b/tests/Rules/IsbnTest.php
@@ -69,6 +69,7 @@ class IsbnTest extends TestCase
             [false, 'ABC'],
             [false, '978-0-306-40615-6'],
             [false, '99921-58-10-6'],
+            [false, '0123456789012'],
         ];
     }
 
@@ -122,6 +123,7 @@ class IsbnTest extends TestCase
             [false, 'ABC'],
             [false, '978-0-306-40615-6'],
             [false, '99921-58-10-6'],
+            [false, '0123456789012'],
         ];
     }
 }


### PR DESCRIPTION
According to the ISBN specification, a certain prefix has been assigned to ISBN numbers. I have added a check for this, since it would pass validation for valid GTIN numbers that are not actually ISBN numbers.

_For a 13-digit ISBN, a prefix element – a [GS1](https://en.wikipedia.org/wiki/GS1) prefix: so far 978 or 979 have been made available by GS1_.