### PR TITLE
Update Dockerfile with simpler Composer copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,4 @@ RUN apt update \
             intl \
         && apt-get clean
 
-# install composer
-#
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
Leverage the [COPY --from](https://docs.docker.com/engine/reference/builder/#from) utility to install Composer.


